### PR TITLE
Feat/7 change translate request function

### DIFF
--- a/src/translate/components/BtnGroup.tsx
+++ b/src/translate/components/BtnGroup.tsx
@@ -1,100 +1,32 @@
-import {
-  Button,
-  ButtonGroup,
-  createStyles,
-  Grow,
-  makeStyles,
-  MuiThemeProvider,
-  Theme,
-  Typography,
-} from '@material-ui/core'
+import { ButtonGroup, Grow, Theme } from '@material-ui/core'
 import React from 'react'
-import { Colors } from '../../color/Color'
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    kakao: {
-      background: Colors.SummerTime,
-      whiteSpace: 'pre-line',
-      padding: theme.spacing(3),
-    },
-    papago: {
-      background: Colors.BlueCuracao,
-      whiteSpace: 'pre-line',
-      padding: theme.spacing(3),
-    },
-    google: {
-      background: Colors.CornFlower,
-      whiteSpace: 'pre-line',
-      padding: theme.spacing(3),
-    },
-    buttonGroup: {
-      '& Button': {
-        marginTop: theme.spacing(2),
-        marginBottom: theme.spacing(2),
-        textTransform: 'none',
-        textAlign: 'left',
-        '@media (min-width: 320px) and (max-width: 480px)': {
-          fontSize: '0.5rem',
-        },
-        textSizeAdjust: 'none',
-      },
-    },
-  })
-)
-
+import TranslationBtn from './TranslationBtn'
 interface Props {
   readonly isShowing: boolean
   readonly handleClick: (
     event: React.MouseEvent<HTMLButtonElement>
   ) => Promise<void>
   readonly typography: Theme
-  readonly kakao: string
-  readonly papago: string
-  readonly google: string
+  readonly translationTexts: string[]
 }
 
 const BtnGroup: React.FC<Props> = (props) => {
-  const { isShowing, handleClick, typography, kakao, papago, google } = props
-  const classes = useStyles()
+  const { isShowing, handleClick, typography, translationTexts } = props
+
+  const displayBtns = translationTexts.map((text, index) => (
+    <TranslationBtn
+      handleClick={handleClick}
+      typography={typography}
+      text={text}
+      key={index}
+    />
+  ))
+
   return (
     <div>
       <Grow in={isShowing} {...(isShowing ? { timeout: 1000 } : {})}>
-        <ButtonGroup
-          orientation="vertical"
-          size="large"
-          fullWidth={true}
-          className={classes.buttonGroup}
-        >
-          <Button
-            className={classes.kakao}
-            onClick={handleClick}
-            variant="contained"
-          >
-            <MuiThemeProvider theme={typography}>
-              <Typography variant="h6">{kakao}</Typography>
-            </MuiThemeProvider>
-          </Button>
-
-          <Button
-            className={classes.papago}
-            onClick={handleClick}
-            variant="contained"
-          >
-            <MuiThemeProvider theme={typography}>
-              <Typography variant="h6">{papago}</Typography>
-            </MuiThemeProvider>
-          </Button>
-
-          <Button
-            className={classes.google}
-            onClick={handleClick}
-            variant="contained"
-          >
-            <MuiThemeProvider theme={typography}>
-              <Typography variant="h6">{google}</Typography>
-            </MuiThemeProvider>
-          </Button>
+        <ButtonGroup orientation="vertical" size="large" fullWidth={true}>
+          {displayBtns}
         </ButtonGroup>
       </Grow>
     </div>

--- a/src/translate/components/TranslationBtn.tsx
+++ b/src/translate/components/TranslationBtn.tsx
@@ -1,0 +1,56 @@
+import {
+  Button,
+  createStyles,
+  makeStyles,
+  MuiThemeProvider,
+  Theme,
+  Typography,
+} from '@material-ui/core'
+import React from 'react'
+import { Colors } from '../../color/Color'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button: {
+      width: '100%',
+      background: Colors.CornFlower,
+      whiteSpace: 'pre-line',
+      padding: theme.spacing(3),
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+      textTransform: 'none',
+      '@media (min-width: 320px) and (max-width: 480px)': {
+        fontSize: '0.5rem',
+      },
+      textSizeAdjust: 'none',
+    },
+  })
+)
+
+interface Props {
+  readonly handleClick: (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => Promise<void>
+  readonly typography: Theme
+  readonly text: string
+}
+
+const TranslationBtn: React.FC<Props> = (props: Props) => {
+  const { handleClick, typography, text } = props
+  const classes = useStyles()
+  return (
+    <div>
+      <Button
+        className={classes.button}
+        onClick={handleClick}
+        variant="contained"
+      >
+        <MuiThemeProvider theme={typography}>
+          <Typography variant="h6">{text}</Typography>
+        </MuiThemeProvider>
+      </Button>
+    </div>
+  )
+}
+
+export default TranslationBtn


### PR DESCRIPTION
이전
1. 구글, 카카오, 파파고 번역 요청 방식 Promise.all 함수 사용했음
2. BtnGroup이 번역 텍스트 버튼 3개를 포함하고 있었음
3. 구글, 카카오, 파파고 번역 텍스트를 각각 변수에 담아 사용했음

현재
1. Promise.allSettled 함수를 사용해 요청 실패시 전체 실패가 아닌 부분 실패로 번역된 텍스트만 번역 텍스트 버튼에 표시
2. BtnGroup에서 TranslationBtn 컴포넌트로 번역 텍스트 버튼 분리
3.  TranslationTexts 라는 string[] 에 번역 텍스트 값을 저장함